### PR TITLE
Allow size to be a string

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -42,7 +42,7 @@ export interface Props extends SVGProps {
   onChange: (checked: boolean) => void;
   checked: boolean;
   style?: React.CSSProperties;
-  size?: number;
+  size?: number|string;
   animationProperties?: typeof defaultProperties;
   moonColor?: string;
   sunColor?: string;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -42,7 +42,7 @@ export interface Props extends SVGProps {
   onChange: (checked: boolean) => void;
   checked: boolean;
   style?: React.CSSProperties;
-  size?: number|string;
+  size?: number | string;
   animationProperties?: typeof defaultProperties;
   moonColor?: string;
   sunColor?: string;


### PR DESCRIPTION
Size should also be a string to support em sizes:
```jsx
    <DarkModeSwitch
      checked={colorMode === "default"}
      onChange={() => setColorMode(colorMode === "default" ? "dark" : "default")}
      size={"1em"}
      moonColor={"var(--theme-ui-colors-accent)"}
      sunColor={"var(--theme-ui-colors-primary)"}
    />
```